### PR TITLE
Integrate Scalar API docs into OrderAPI and UserAPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
           dotnet-version: '9.0.x'
       
       - name: Restore dependencies
-        run: dotnet restore K4-TeamProj.sln
+        run: dotnet restore K4-TeamProj.slnx
       
       - name: Build project
-        run: dotnet build K4-TeamProj.sln --configuration Release --no-restore
+        run: dotnet build K4-TeamProj.slnx --configuration Release --no-restore
       
       - name: Run tests
-        run: dotnet test K4-TeamProj.sln --configuration Release --no-build --verbosity normal
+        run: dotnet test K4-TeamProj.slnx --configuration Release --no-build --verbosity normal

--- a/OrderAPI/OrderAPI.csproj
+++ b/OrderAPI/OrderAPI.csproj
@@ -8,6 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+		<PackageReference Include="Scalar.AspNetCore" Version="2.13.22" />
 	</ItemGroup>
 
   <ItemGroup>

--- a/OrderAPI/Program.cs
+++ b/OrderAPI/Program.cs
@@ -1,3 +1,5 @@
+using Scalar.AspNetCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -12,6 +14,7 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
+    app.MapScalarApiReference();
 }
 
 app.UseHttpsRedirection();

--- a/OrderAPI/Properties/launchSettings.json
+++ b/OrderAPI/Properties/launchSettings.json
@@ -2,22 +2,24 @@
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:5298",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": true,
+        "launchUrl": "scalar/v1",
+        "applicationUrl": "http://localhost:5298",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        }
     },
     "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "https://localhost:7092;http://localhost:5298",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": true,
+        "launchUrl": "scalar/v1",
+        "applicationUrl": "https://localhost:7092;http://localhost:5298;",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        }
     }
   }
 }

--- a/UserAPI/Program.cs
+++ b/UserAPI/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Scalar.AspNetCore;
 using UserAPI.Data;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -23,6 +24,8 @@ if (app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error");
     app.UseHsts();
+    app.MapOpenApi();
+    app.MapScalarApiReference();
 }
 
 app.UseHttpsRedirection();

--- a/UserAPI/Properties/launchSettings.json
+++ b/UserAPI/Properties/launchSettings.json
@@ -2,22 +2,24 @@
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:5047",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": true,
+        "launchUrl": "scalar/v1",
+        "applicationUrl": "http://localhost:5047",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        }
     },
     "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "https://localhost:7221;http://localhost:5047",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": true,
+        "launchUrl": "scalar/v1",
+        "applicationUrl": "https://localhost:7221;http://localhost:5047",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        }
     }
   }
 }

--- a/UserAPI/UserAPI.csproj
+++ b/UserAPI/UserAPI.csproj
@@ -15,6 +15,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
+		<PackageReference Include="Scalar.AspNetCore" Version="2.13.22" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Integrate Scalar API docs into OrderAPI and UserAPI

Added Scalar.AspNetCore to both APIs and configured Program.cs to expose interactive API documentation at /scalar/v1 during development. Updated launch settings to launch the browser to the Scalar UI by default.