### PR TITLE
feature: add TimeLogs and Categories controllers with pagination and CRUD endpoints

### DIFF
--- a/TimelogAPI/Controllers/CategoriesController.cs
+++ b/TimelogAPI/Controllers/CategoriesController.cs
@@ -1,6 +1,53 @@
-﻿namespace TimelogAPI.Controllers
+﻿using Microsoft.AspNetCore.Mvc;
+using TimelogAPI.Features.Categories.Dtos;
+using TimelogAPI.Services;
+
+namespace TimelogAPI.Controllers
 {
-    public class CategoriesController
+    [Route("api/[controller]")]
+    [ApiController]
+    public class CategoriesController : ControllerBase
     {
+        private readonly ICategoryService _categoryService;
+        public CategoriesController(ICategoryService categoryService)
+        {
+            _categoryService = categoryService;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateCategory([FromBody] CreateCategoryRequest request)
+        {
+            var result = await _categoryService.CreateCategoryAsync(request);
+            return CreatedAtAction(nameof(GetCategoryById), new { id = result.Id }, result);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetCategoryById(int id)
+        {
+            var result = await _categoryService.GetCategoryByIdAsync(id);
+            return Ok(result);              
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetCategories([FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        [FromQuery] string? searchTerm = null)
+        {
+            var result = await _categoryService.GetPagedCategoriesAsync(page, pageSize, searchTerm);
+            return Ok(result);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateCategory(int id, [FromBody] UpdateCategoryRequest request)
+        {
+            var result = await _categoryService.UpdateCategoryAsync(id, request);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteCategory(int id)
+        {
+            var result = await _categoryService.DeleteCategoryAsync(id);
+            return NoContent();
+        }
     }
-}

--- a/TimelogAPI/Controllers/CategoriesController.cs
+++ b/TimelogAPI/Controllers/CategoriesController.cs
@@ -1,0 +1,6 @@
+﻿namespace TimelogAPI.Controllers
+{
+    public class CategoriesController
+    {
+    }
+}

--- a/TimelogAPI/Controllers/CategoriesController.cs
+++ b/TimelogAPI/Controllers/CategoriesController.cs
@@ -25,7 +25,7 @@ namespace TimelogAPI.Controllers
         public async Task<IActionResult> GetCategoryById(int id)
         {
             var result = await _categoryService.GetCategoryByIdAsync(id);
-            return Ok(result);              
+            return Ok(result);
         }
 
         [HttpGet]
@@ -40,14 +40,15 @@ namespace TimelogAPI.Controllers
         [HttpPut("{id}")]
         public async Task<IActionResult> UpdateCategory(int id, [FromBody] UpdateCategoryRequest request)
         {
-            var result = await _categoryService.UpdateCategoryAsync(id, request);
+            await _categoryService.UpdateCategoryAsync(id, request);
             return NoContent();
         }
 
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteCategory(int id)
         {
-            var result = await _categoryService.DeleteCategoryAsync(id);
+            await _categoryService.DeleteCategoryAsync(id);
             return NoContent();
         }
     }
+}

--- a/TimelogAPI/Controllers/TimelogsController.cs
+++ b/TimelogAPI/Controllers/TimelogsController.cs
@@ -1,6 +1,55 @@
-﻿namespace TimelogAPI.Controllers
+﻿using Microsoft.AspNetCore.Mvc;
+using TimelogAPI.Features.TimeLogs.Dtos;
+using TimelogAPI.Services;
+
+namespace TimelogAPI.Controllers
 {
-    public class TimelogsController
+    [Route("api/[controller]")]
+    [ApiController]
+    public class TimelogsController : ControllerBase
     {
+        private readonly ITimelogService _timelogService;
+        public TimelogsController(ITimelogService timelogService)
+        {
+            _timelogService = timelogService;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateTimelog([FromBody] CreateTimeLogRequest request)
+        {
+            var result = await _timelogService.CreateTimelogAsync(request);
+            return CreatedAtAction(nameof(GetTimelogById), new { id = result.Id }, result);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetTimelogById(int id)
+        {
+            var result = await _timelogService.GetTimelogByIdAsync(id);
+            return Ok(result);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetTimelogs([FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        [FromQuery] string? category = null,
+        [FromQuery] string? sortBy = null)
+        {
+            var result = await _timelogService.GetTimelogsAsync(category, sortBy, page, pageSize);
+            return Ok(result);
+        }
+
+        [HttpPut("{id}")]
+
+        public async Task<IActionResult> UpdateTimelog(int id,[FromBody] UpdateTimeLogRequest request)
+        {
+            var result = await _timelogService.UpdateTimelogAsync(id, request);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteTimelog(int id)
+        {
+            var result = await _timelogService.DeleteTimelogAsync(id);
+            return NoContent();
+        }
     }
-}

--- a/TimelogAPI/Controllers/TimelogsController.cs
+++ b/TimelogAPI/Controllers/TimelogsController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using TimelogAPI.Features.Common;
 using TimelogAPI.Features.TimeLogs.Dtos;
 using TimelogAPI.Services;
 
@@ -29,27 +30,29 @@ namespace TimelogAPI.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> GetTimelogs([FromQuery] int page = 1,
-        [FromQuery] int pageSize = 20,
-        [FromQuery] string? category = null,
-        [FromQuery] string? sortBy = null)
+        public async Task<IActionResult> GetTimelogs(
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 20,
+            [FromQuery] string? category = null,
+            [FromQuery] DateTime? startDate = null)
         {
-            var result = await _timelogService.GetTimelogsAsync(category, sortBy, page, pageSize);
+            var result = await _timelogService.GetPagedTimelogsAsync(page, pageSize, startDate, category);
             return Ok(result);
         }
 
         [HttpPut("{id}")]
 
-        public async Task<IActionResult> UpdateTimelog(int id,[FromBody] UpdateTimeLogRequest request)
+        public async Task<IActionResult> UpdateTimelog(int id, [FromBody] UpdateTimeLogRequest request)
         {
-            var result = await _timelogService.UpdateTimelogAsync(id, request);
+            await _timelogService.UpdateTimelogAsync(id, request);
             return NoContent();
         }
 
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteTimelog(int id)
         {
-            var result = await _timelogService.DeleteTimelogAsync(id);
+            await _timelogService.DeleteTimelogAsync(id);
             return NoContent();
         }
     }
+}

--- a/TimelogAPI/Controllers/TimelogsController.cs
+++ b/TimelogAPI/Controllers/TimelogsController.cs
@@ -1,0 +1,6 @@
+﻿namespace TimelogAPI.Controllers
+{
+    public class TimelogsController
+    {
+    }
+}

--- a/TimelogAPI/Services/ITimelogService.cs
+++ b/TimelogAPI/Services/ITimelogService.cs
@@ -1,13 +1,14 @@
 using TimelogAPI.Features.Common;
 using TimelogAPI.Features.TimeLogs.Dtos;
 
-namespace TimelogAPI.Services;
+namespace TimelogAPI.Services { 
 
-public interface ITimelogService
-{
-    Task<PagedResponseDto<TimeLogResponse>> GetPagedTimeLogsAsync(int page, int pageSize, DateTime? startDate, string? category);
-    Task<TimeLogResponse> GetTimeLogByIdAsync(int id);
-    Task<TimeLogResponse> CreateTimeLogAsync(CreateTimeLogRequest request);
-    Task<bool> UpdateTimeLogAsync(UpdateTimeLogRequest request);
-    Task<bool> DeleteTimeLogAsync(int id);
+    public interface ITimelogService
+    {
+        Task<PagedResponseDto<TimeLogResponse>> GetPagedTimelogsAsync(int page, int pageSize, DateTime? startDate, string? category);
+        Task<TimeLogResponse> GetTimelogByIdAsync(int id);
+        Task<TimeLogResponse> CreateTimelogAsync(CreateTimeLogRequest request);
+        Task<bool> UpdateTimelogAsync(int id, UpdateTimeLogRequest request);
+        Task<bool> DeleteTimelogAsync(int id);
+    }
 }

--- a/TimelogAPI/Services/TimleogService.cs
+++ b/TimelogAPI/Services/TimleogService.cs
@@ -10,8 +10,8 @@ namespace TimelogAPI.Services
     {
         private readonly ILogger<TimleogService> _logger;
 
-        // In-memory data store for TimeLogs
-        private static readonly List<TimeLog> _TimeLogs = Enumerable.Range(1, 20).Select(i =>
+        // In-memory data store for Timelogs
+        private static readonly List<TimeLog> _timelogs = Enumerable.Range(1, 20).Select(i =>
         {
             var randomCategoryId = new Random().Next(1, 4);
             var category = CategoryService._categories.FirstOrDefault(c => c.Id == randomCategoryId);
@@ -34,9 +34,9 @@ namespace TimelogAPI.Services
         }
 
 
-    public async Task<PagedResponseDto<TimeLogResponse>> GetPagedTimeLogsAsync(int page, int pageSize, DateTime? startDate, string? category)
+    public async Task<PagedResponseDto<TimeLogResponse>> GetPagedTimelogsAsync(int page, int pageSize, DateTime? startDate, string? category)
         {
-            var query = _TimeLogs.AsQueryable();
+            var query = _timelogs.AsQueryable();
 
             // Filtering
             if (startDate.HasValue)
@@ -57,26 +57,26 @@ namespace TimelogAPI.Services
             return query.ToPagedResponse(page, pageSize, t => t.ToResponse());
         }
 
-    public async Task<TimeLogResponse> GetTimeLogByIdAsync(int id)
+    public async Task<TimeLogResponse> GetTimelogByIdAsync(int id)
         {
-            var timeLog = _TimeLogs.FirstOrDefault(t => t.Id == id);
+            var timeLog = _timelogs.FirstOrDefault(t => t.Id == id);
             return timeLog?.ToResponse()!;
         }
 
-        public async Task<TimeLogResponse> CreateTimeLogAsync(CreateTimeLogRequest request)
+        public async Task<TimeLogResponse> CreateTimelogAsync(CreateTimeLogRequest request)
         {
             var entity = request.ToEntity();
             entity.Id = _nextId++;
 
             entity.Category = CategoryService._categories.FirstOrDefault(c => c.Id == entity.CategoryId);
 
-            _TimeLogs.Add(entity);
+            _timelogs.Add(entity);
             return entity.ToResponse();
         }
 
-        public async Task<bool> UpdateTimeLogAsync(UpdateTimeLogRequest request)
+        public async Task<bool> UpdateTimelogAsync(int id, UpdateTimeLogRequest request)
         {
-            var existing = _TimeLogs.FirstOrDefault(t => t.Id == request.CategoryId);
+            var existing = _timelogs.FirstOrDefault(t => t.Id == id);
             if (existing == null) return false;
 
             request.UpdateEntity(existing);
@@ -86,12 +86,12 @@ namespace TimelogAPI.Services
             return true;
         }
 
-        public async Task<bool> DeleteTimeLogAsync(int id)
+        public async Task<bool> DeleteTimelogAsync(int id)
         {
-            var existing = _TimeLogs.FirstOrDefault(t => t.Id == id);
+            var existing = _timelogs.FirstOrDefault(t => t.Id == id);
             if (existing == null) return false;
 
-            _TimeLogs.Remove(existing);
+            _timelogs.Remove(existing);
             return true;
         }
     }

--- a/TimelogAPI/TimelogAPI.csproj
+++ b/TimelogAPI/TimelogAPI.csproj
@@ -11,8 +11,4 @@
 		<PackageReference Include="Scalar.AspNetCore" Version="2.13.22" />
 	</ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Controllers\" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Implemented TimelogsController and CategoriesController with full CRUD operations (GET, POST, PUT, DELETE). 
Both list endpoints support pagination via query parameters (page, pageSize). 
Categories also support searchTerm filtering in case it is needed, otherwise i can remove them.