### PR TITLE
Add XML docs to controllers and enable doc generation

### DIFF
--- a/ProxyAPI/ProxyAPI.csproj
+++ b/ProxyAPI/ProxyAPI.csproj
@@ -6,6 +6,12 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+		<NoWarn>$(NoWarn);1591</NoWarn>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.0" />

--- a/TimelogAPI/Controllers/CategoriesController.cs
+++ b/TimelogAPI/Controllers/CategoriesController.cs
@@ -4,6 +4,9 @@ using TimelogAPI.Services;
 
 namespace TimelogAPI.Controllers
 {
+    /// <summary>
+    /// Hanterar kategorier för tidrapportering.
+    /// </summary>
     [Route("api/[controller]")]
     [ApiController]
     public class CategoriesController : ControllerBase
@@ -14,6 +17,13 @@ namespace TimelogAPI.Controllers
             _categoryService = categoryService;
         }
 
+        /// <summary>
+        /// Skapar en ny kategori.
+        /// </summary>
+        /// <param name="request">Data för den nya kategorin.</param>
+        /// <returns>Den nyskapade kategorin.</returns>
+        /// <response code="201">Returnerar den nyskapade kategorin.</response>
+        /// <response code="400">Om förfrågan är felaktig.</response>
         [HttpPost]
         public async Task<IActionResult> CreateCategory([FromBody] CreateCategoryRequest request)
         {
@@ -21,6 +31,13 @@ namespace TimelogAPI.Controllers
             return CreatedAtAction(nameof(GetCategoryById), new { id = result.Id }, result);
         }
 
+        /// <summary>
+        /// Hämtar en specifik kategori baserat på ID.
+        /// </summary>
+        /// <param name="id">Kategorins unika identifierare.</param>
+        /// <returns>En kategori.</returns>
+        /// <response code="200">Returnerar den efterfrågade kategorin.</response>
+        /// <response code="404">Om kategorin inte hittades.</response>
         [HttpGet("{id}")]
         public async Task<IActionResult> GetCategoryById(int id)
         {
@@ -28,6 +45,13 @@ namespace TimelogAPI.Controllers
             return Ok(result);
         }
 
+        /// <summary>
+        /// Hämtar en sökbar och siduppdelad lista av kategorier.
+        /// </summary>
+        /// <param name="page">Sidnummer (standardvärde 1).</param>
+        /// <param name="pageSize">Antal resultat per sida (standardvärde 20).</param>
+        /// <param name="searchTerm">Frivillig sökterm för att filtrera kategorier på namn.</param>
+        /// <returns>En lista med kategorier.</returns>
         [HttpGet]
         public async Task<IActionResult> GetCategories([FromQuery] int page = 1,
         [FromQuery] int pageSize = 20,
@@ -37,6 +61,14 @@ namespace TimelogAPI.Controllers
             return Ok(result);
         }
 
+        /// <summary>
+        /// Uppdaterar en befintlig kategori.
+        /// </summary>
+        /// <param name="id">ID för kategorin som ska uppdateras.</param>
+        /// <param name="request">Den uppdaterade datan.</param>
+        /// <returns>Inget innehåll vid lyckad uppdatering.</returns>
+        /// <response code="204">Kategorin har uppdaterats.</response>
+        /// <response code="404">Om kategorin inte existerar.</response>
         [HttpPut("{id}")]
         public async Task<IActionResult> UpdateCategory(int id, [FromBody] UpdateCategoryRequest request)
         {
@@ -44,6 +76,12 @@ namespace TimelogAPI.Controllers
             return NoContent();
         }
 
+        /// <summary>
+        /// Tar bort en kategori.
+        /// </summary>
+        /// <param name="id">ID för kategorin som ska raderas.</param>
+        /// <returns>Inget innehåll vid lyckad borttagning.</returns>
+        /// <response code="204">Kategorin har raderats.</response>
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteCategory(int id)
         {

--- a/TimelogAPI/Controllers/TimelogsController.cs
+++ b/TimelogAPI/Controllers/TimelogsController.cs
@@ -5,6 +5,9 @@ using TimelogAPI.Services;
 
 namespace TimelogAPI.Controllers
 {
+    /// <summary>
+    /// Hanterar tidrapporter och loggning av arbetstid.
+    /// </summary>
     [Route("api/[controller]")]
     [ApiController]
     public class TimelogsController : ControllerBase
@@ -15,6 +18,12 @@ namespace TimelogAPI.Controllers
             _timelogService = timelogService;
         }
 
+        /// <summary>
+        /// Registrerar en ny tidrapport.
+        /// </summary>
+        /// <param name="request">Information om tidrapporten.</param>
+        /// <returns>Den skapade tidrapporten.</returns>
+        /// <response code="201">Tidrapporten har skapats.</response>
         [HttpPost]
         public async Task<IActionResult> CreateTimelog([FromBody] CreateTimeLogRequest request)
         {
@@ -22,6 +31,11 @@ namespace TimelogAPI.Controllers
             return CreatedAtAction(nameof(GetTimelogById), new { id = result.Id }, result);
         }
 
+        /// <summary>
+        /// Hämtar en specifik tidrapport via ID.
+        /// </summary>
+        /// <param name="id">Tidrapportens unika ID.</param>
+        /// <returns>En tidrapport.</returns>
         [HttpGet("{id}")]
         public async Task<IActionResult> GetTimelogById(int id)
         {
@@ -29,6 +43,14 @@ namespace TimelogAPI.Controllers
             return Ok(result);
         }
 
+        /// <summary>
+        /// Hämtar tidrapporter med filtrering och siduppdelning.
+        /// </summary>
+        /// <param name="page">Sidnummer (standardvärde 1).</param>
+        /// <param name="pageSize">Antal resultat per sida (standardvärde 20).</param>
+        /// <param name="category">Filtrera på en specifik kategori.</param>
+        /// <param name="startDate">Hämta loggar från och med detta datum.</param>
+        /// <returns>En lista med tidrapporter.</returns>
         [HttpGet]
         public async Task<IActionResult> GetTimelogs(
             [FromQuery] int page = 1,
@@ -40,14 +62,24 @@ namespace TimelogAPI.Controllers
             return Ok(result);
         }
 
+        /// <summary>
+        /// Uppdaterar en befintlig tidrapport.
+        /// </summary>
+        /// <param name="id">ID för tidrapporten.</param>
+        /// <param name="request">Ny information för tidrapporten.</param>
+        /// <returns>NoContent om uppdateringen lyckades.</returns>
         [HttpPut("{id}")]
-
         public async Task<IActionResult> UpdateTimelog(int id, [FromBody] UpdateTimeLogRequest request)
         {
             await _timelogService.UpdateTimelogAsync(id, request);
             return NoContent();
         }
 
+        /// <summary>
+        /// Tar bort en tidrapport permanent.
+        /// </summary>
+        /// <param name="id">ID för tidrapporten som ska tas bort.</param>
+        /// <returns>NoContent om borttagningen lyckades.</returns>
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteTimelog(int id)
         {

--- a/TimelogAPI/TimelogAPI.csproj
+++ b/TimelogAPI/TimelogAPI.csproj
@@ -6,6 +6,12 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+		<NoWarn>$(NoWarn);1591</NoWarn>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />


### PR DESCRIPTION
Add XML docs to controllers and enable doc generation

Added Swedish XML documentation comments to all API endpoints in CategoriesController and TimelogsController. Enabled XML documentation file generation and suppressed warning 1591 in project files to improve API documentation and Swagger/OpenAPI support.